### PR TITLE
feat(oidc): get roles claim from identity token

### DIFF
--- a/.dev/docker-compose.yaml
+++ b/.dev/docker-compose.yaml
@@ -53,17 +53,38 @@ services:
                 "Value": "superuser"
               },
               {
-                "Type": "custom-claim",
-                "Value": "test custom claim"
+                "Type": "roles",
+                "Value": "['admin', 'some_role']",
+                "ValueType": "json"
+              }
+            ]
+          },
+          {
+            "SubjectId":"2",
+            "Username":"user",
+            "Password":"password",
+            "Claims": [
+              {
+                "Type": "name",
+                "Value": "John Doe"
+              },
+              {
+                "Type": "email",
+                "Value": "john@ohanais.live"
               },
               {
                 "Type": "roles",
-                "Value": "['a', 'b']",
+                "Value": "['test123']",
                 "ValueType": "json"
               }
             ]
           }
         ]
+      IDENTITY_RESOURCES_INLINE: |
+        [{
+          "Name": "app.roles",
+          "ClaimTypes": ["roles"]
+        }]
       CLIENTS_CONFIGURATION_INLINE: |
         [{
             "ClientId": "ohana",
@@ -82,7 +103,8 @@ services:
             "AllowedScopes": [
                 "openid",
                 "profile",
-                "email"
+                "email",
+                "app.roles"
             ],
             "ClientClaimsPrefix": "",
             "Claims": []

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -13,6 +13,8 @@ authentication:
   client_id: ohana
   client_secret: family
   redirect_url: http://localhost:8000/auth/callback
+  scopes: ['openid', 'profile', 'email', 'app.roles']
+  roles_claim_name: roles
 stitch:
   shards_location: shards/
 node:

--- a/config/config.go
+++ b/config/config.go
@@ -45,6 +45,10 @@ type AuthConfig struct {
 	ClientSecret string `yaml:"client_secret"`
 	// URL for the callback after authentication
 	RedirectURL string `yaml:"redirect_url"`
+	// Scopes to request to the identity provider
+	Scopes []string `yaml:"scopes"`
+	// The name of the claim which will contain user roles
+	RolesClaimName string `yaml:"roles_claim_name"`
 }
 
 type RedisConfig struct {

--- a/service/auth_service.go
+++ b/service/auth_service.go
@@ -38,6 +38,7 @@ type Auth interface {
 type auth struct {
 	provider     *oidc.Provider
 	verifier     *oidc.IDTokenVerifier
+	authConfig   *config.AuthConfig
 	oauth2Config *oauth2.Config
 	db           *gorm.DB
 	sess         Session
@@ -59,20 +60,23 @@ func NewAuth(c *config.Config, db *gorm.DB, sess Session) (Auth, error) {
 	}
 	verifier := provider.Verifier(oidcConfig)
 
+	// Get the auth config
+	authConfig := c.Authentication
+
 	return &auth{
 		provider: provider,
 		verifier: verifier,
 		oauth2Config: &oauth2.Config{
-			ClientID:     c.Authentication.ClientID,
-			ClientSecret: c.Authentication.ClientSecret,
-			RedirectURL:  c.Authentication.RedirectURL,
+			ClientID:     authConfig.ClientID,
+			ClientSecret: authConfig.ClientSecret,
+			RedirectURL:  authConfig.RedirectURL,
 			// Discovery returns the OAuth2 endpoints.
 			Endpoint: provider.Endpoint(),
-			// "openid" is a required scope for OpenID Connect flows.
-			Scopes: []string{oidc.ScopeOpenID, "profile", "email"},
+			Scopes:   authConfig.Scopes,
 		},
-		db:   db,
-		sess: sess,
+		db:         db,
+		sess:       sess,
+		authConfig: &authConfig,
 	}, nil
 }
 
@@ -115,9 +119,19 @@ func (a *auth) Callback(ctx context.Context, code string, checkState string) (*c
 		return nil, fmt.Errorf("Failed to verify ID Token: %w", err)
 	}
 
+	// Parse the standard claims
 	var idTokenClaims claims
 	if err := idToken.Claims(&idTokenClaims); err != nil {
 		return nil, fmt.Errorf("Failed to parse ID Token claims: %w", err)
+	}
+
+	// Parse the roles claim
+	var allClaims map[string]interface{}
+	if err := idToken.Claims(&allClaims); err != nil {
+		return nil, fmt.Errorf("Failed to parse ID Token claims: %w", err)
+	}
+	if roles, ok := allClaims["roles"].([]string); ok {
+		idTokenClaims.Roles = roles
 	}
 
 	// Create user in DBFS if not exists
@@ -132,6 +146,8 @@ func (a *auth) Callback(ctx context.Context, code string, checkState string) (*c
 			return nil, fmt.Errorf("Failed to create new user: %w", err)
 		}
 	}
+
+	// TODO: Map roles to groups, and assign user to groups
 
 	// Create session ID from user ID
 	sessionId, err := a.sess.Create(ctx, user.UserId, time.Hour*24*7)


### PR DESCRIPTION
This PR:
- Updates the mock OIDC server to add another user, and to add a `roles` claim by requesting the `app.roles` scope.
- Adds additional keys to the auth configuration
  - `scopes` is an array of scopes that should be requested to the identity provider
  - `roles_claim_name` specifies the name of the claim within the ID token which contains the array of roles