### PR TITLE
vite: proxy /api and /auth to backend

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,7 +1,13 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()]
-})
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8000',
+      '/auth': 'http://localhost:8000',
+    },
+  },
+});


### PR DESCRIPTION
This allows devs to open the page on localhost:3000 and still be able to access the API.